### PR TITLE
use torch.matmul over torch.mm for coreml compatibility. Add apply_lo…

### DIFF
--- a/minlora/model.py
+++ b/minlora/model.py
@@ -33,7 +33,7 @@ class LoRAParametrization(nn.Module):
         return A * self.lora_dropout(self.lora_dropout_mask)
 
     def lora_forward(self, X):
-        return X + torch.mm(*self.swap((self.lora_B, self.dropout_fn(self.lora_A)))).view(X.shape) * self.scaling
+        return X + torch.matmul(*self.swap((self.lora_B, self.dropout_fn(self.lora_A)))).view(X.shape) * self.scaling
 
     def forward(self, X):
         return self.forward_fn(X)
@@ -83,6 +83,13 @@ def apply_lora(layer, register=True, merge=False, lora_config=default_lora_confi
         if hasattr(layer, "parametrizations"):
             for attr_name in layer.parametrizations.keys():
                 parametrize.remove_parametrizations(layer, attr_name, leave_parametrized=merge)
+
+
+def apply_lora_by_name(model, target_module_names, register=True, merge=False, lora_config=default_lora_config):
+    """Add LoRA parameterization to specific layers in a model by names"""
+    for name, layer in model.named_modules():
+        if any([m in name for m in target_module_names]):
+            add_lora(layer, register=register, merge=merge, lora_config=lora_config)
 
 
 def add_lora(model, lora_config=default_lora_config):

--- a/minlora/model.py
+++ b/minlora/model.py
@@ -85,16 +85,16 @@ def apply_lora(layer, register=True, merge=False, lora_config=default_lora_confi
                 parametrize.remove_parametrizations(layer, attr_name, leave_parametrized=merge)
 
 
-def apply_lora_by_name(model, target_module_names, register=True, merge=False, lora_config=default_lora_config):
-    """Add LoRA parameterization to specific layers in a model by names"""
-    for name, layer in model.named_modules():
-        if any([m in name for m in target_module_names]):
-            add_lora(layer, register=register, merge=merge, lora_config=lora_config)
-
-
 def add_lora(model, lora_config=default_lora_config):
     """add lora parametrization to all layers in a model. Calling it twice will add lora twice"""
     model.apply(partial(apply_lora, lora_config=lora_config))
+
+
+def add_lora_by_name(model, target_module_names, lora_config=default_lora_config):
+    """Add LoRA parameterization to specific layers in a model by names"""
+    for name, layer in model.named_modules():
+        if any([m in name for m in target_module_names]):
+            add_lora(layer, lora_config=lora_config)
 
 
 def merge_lora(model):


### PR DESCRIPTION
When I used `minLoRA` to train a model and convert it to coreml using coremltools I hit and error that `mm` was not recognized, switching to matmul fixes that error.

I also added a convenience function to loop through layers in a model and apply lora to layers whose name matches specified target names